### PR TITLE
Fixed unsigned/signed comparison warning.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ OBJECTS := \
 all: mkbin bin/pixelsort
 
 bin/pixelsort: $(OBJECTS)
-	$(LD) -o $(@) $(CXXFLAGS) $(LDFLAGS) $(^)
+	$(LD) -o $(@) $(CXXFLAGS) $(^) $(LDFLAGS)
 
 mkbin:
 	mkdir -p $(BIN)

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -92,7 +92,7 @@ PixelSortQuery_t * process_tokens(const char* query_string) {
 }
 
 void destroy_query(PixelSortQuery_t * query) {
-    for(int i = 0; i < query->subquery_count; ++i) {
+    for(size_t i = 0; i < query->subquery_count; ++i) {
 	free(query->subqueries[i]);
     }
     free(query);


### PR DESCRIPTION
Also fixed LDFLAG ordering issue.

On my system (Ubuntu 14.04), the previous ordering caused a compilation error.

Also, I set -Wsign-compare and -Werror. So I changed int to size_t. Probably could have simply done unsigned int...
